### PR TITLE
Fix package name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-package",
+  "name": "webppl-package-template",
   "version": "0.0.1",
   "description": "WebPPL library for ...",  
   "webppl": {


### PR DESCRIPTION
WebPPL will soon take the name of the global var used for imported JS code from `package.json`, rather than using the name of the directory the package happens to be in.
